### PR TITLE
Update to JMeter three

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+Gemfile.lock
+jmeter.log
+ruby-jmeter.jmx

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem 'ruby-jmeter'
+gem 'ruby-jmeter', "~> 3.0"

--- a/README.md
+++ b/README.md
@@ -5,9 +5,21 @@ A [ruby-jmeter](https://github.com/flood-io/ruby-jmeter) script for a performanc
 
 ## Setup
 
-Download jmeter into the `apache-jmeter-2.13` folder as well as JMeterPlugins-ExtraLibs [from here](http://jmeter-plugins.org/downloads/all/)
+You need jmeter 3 along with the new [Plugins Manager](https://jmeter-plugins.org/wiki/PluginsManager/) installed in your `$PATH`, and the following plugins need to be installed:
+
+- "3 Basic Graphs"
+- "JSON Plugins"
+
+Under OSX, this can be accomplished by simply running
+```
+brew install jmeter --with-plugins
+```
+
+At this point, start a sandbox in a different terminal, and then do:
 
 ```
 bundle
 bundle exec ruby testplan.rb
 ```
+
+Pro Tip: No SQLite with performance testing. It's not good for that.

--- a/testplan.rb
+++ b/testplan.rb
@@ -112,7 +112,7 @@ test do
   graph_results
   response_time_graph
   summary_report
-  transactions_per_second "transactions per 30s", interval_grouping: 30000
+  transactions_per_second name: "transactions per 30s", interval_grouping: 30000
   view_results_tree
   assertion_results
 
@@ -127,4 +127,4 @@ test do
       SolidusDriver.new(self).perform
     end
   end
-end.run(path: './apache-jmeter-2.13/bin/', gui: true)
+end.run(path: File.dirname(`which jmeter`), gui: true)

--- a/testplan.rb
+++ b/testplan.rb
@@ -57,11 +57,11 @@ class SolidusDriver < RailsDriver
       'quantity'           => '1'
     }
     visit '/checkout'
-    put '/checkout/registration', order: {email: 'test@example.com'} do
+    put '/checkout/registration', {'order' => { 'email' => 'test@example.com'}, "commit" => "Continue" } do
       extract xpath: '//select[@name="order[bill_address_attributes][country_id]"]/option[text()="United States of America"]/@value', name: 'country_id', tolerant: true
     end
     visit '/api/states?country_id=${country_id}' do
-      extract name: 'state_id', json: "$.states[?(@.name=='New York')][0].id"
+      extract name: 'state_id', json: "$.states[?(@.name=='New York')].id"
     end
     patch '/checkout/update/address', order: {
       bill_address_attributes: {
@@ -70,7 +70,7 @@ class SolidusDriver < RailsDriver
         address1: '53rd & 3rd',
         city: 'New York',
         country_id: '${country_id}',
-        state_id: '${state_id}',
+        state_id: '${state_id_1}',
         zipcode: '10001',
         phone: '5555555555'
       },
@@ -120,7 +120,7 @@ test do
   #defaults domain: 'demo.solidus.io', protocol: 'https', download_resources: false, use_concurrent_pool: 5
 
   cache clear_each_iteration: true
-  cookies policy: "standard"
+  cookies policy: "standard", clear_each_iteration: true
 
   threads count: 10, duration: 240 do
     transaction 'checkout' do

--- a/testplan.rb
+++ b/testplan.rb
@@ -120,7 +120,7 @@ test do
   #defaults domain: 'demo.solidus.io', protocol: 'https', download_resources: false, use_concurrent_pool: 5
 
   cache clear_each_iteration: true
-  cookies
+  cookies policy: "standard"
 
   threads count: 10, duration: 240 do
     transaction 'checkout' do


### PR DESCRIPTION
This 
- gitignores `lock` and `log` files
- version constraints `ruby-jmeter` to `~>3.0`
- removes hardcoding jmeters location on your computer
- changes one method call because its signature been changed in `ruby-jmeter` 3
- adds some more docs
